### PR TITLE
FC-219 | Adding optional cursor pagination options to support reading from secondary

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -33,6 +33,7 @@ const config = require('./config');
  *    -previous {String} The value to start querying previous page.
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
+ *    -options {Object} An object of options for implementing features like read preference (https://docs.mongodb.com/manual/core/read-preference/).
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
@@ -66,7 +67,15 @@ module.exports = async function aggregate(collection, params) {
    *
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
-  const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
+  let options = config.COLLATION ? { collation: config.COLLATION } : {};
+
+  // Spread options passed in as a parameter
+  if (params.options) {
+    options = {
+      ...options,
+      ...params.options,
+    };
+  }
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations


### PR DESCRIPTION
#### Changes Made
Support for passing in an `options` object param allowing for options beyond just collation to be set on an aggregation.  The missing feature here that I needed was readPreference. 
```
options: {
  readPreference: 'secondaryPreferred',
}
```

#### Potential Risks
None I'm aware of as it will not have any effect on the use without the new feature.

#### Test Plan
- Run queries without passing in a new readPreference and confirm things still function correctly, and that the default readPref is applied.
- Run queries with options: `{ readPreference: 'secondaryPreferred' }` specified and confirm the readPref is properly applied.