### PR TITLE
Simplify paginated queries with no next/prev

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -38,7 +38,9 @@ module.exports = async function(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const findMethod = collection.findAsCursor ? 'findAsCursor' : 'find';
 
-  const query = collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields);
+  // If cursorQuery is empty, we can just send `params.query` as-is with the same result.
+  const predicate = Object.keys(cursorQuery).length === 0 ? params.query : { $and: [cursorQuery, params.query] };
+  const query = collection[findMethod](predicate, params.fields);
 
   /**
    * IMPORTANT


### PR DESCRIPTION
Right now this plugin sends queries for a first page of results that look like:

    collection.find({ $and: [{}, {...query...}] });

This change simplifies those to `collection.find(query)`. It shouldn't result in much better performance, but it will definitely improve observability (as it will be easier to see the exact shape of the query that was passed in logging/monitoring tools).

#### Changes Made
- If the 'cursor query' (that is, the part of the query related to next/prev pages) is empty, replace the top-level `$and` (which will thus be tautological) with the called-provided query as-is.

#### Potential Risks
* If we were relying on queries looking like `{ $and: [ {}, {...} ] }`, something could break.
* Existing monitoring tools that assume all `someCollection.find({ $and: "?" })` queries are pagination queries will start to see different query shapes for those first-page queries with no prev/next params, and could behave in undefined ways.

#### Test Plan
* This is a very small change that should not affect the current behavior, and thus should be adequately covered by the existing unit tests.

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
